### PR TITLE
Use `change` event instead of `input`

### DIFF
--- a/addon/components/x-range-input.js
+++ b/addon/components/x-range-input.js
@@ -69,12 +69,12 @@ export default Ember.Component.extend({
   }),
 
   /**
-   * On any `input` event, take the component and the element `value` and send
+   * On any `change` event, take the component and the element `value` and send
    * it in an action.
    *
    * @private
    */
-  input() {
+  change() {
     let newValue = Number(this.get('element.value')).valueOf();
 
     // Allow old school 2 way binding with the `mut` helper

--- a/tests/acceptance/x-range-input-test.js
+++ b/tests/acceptance/x-range-input-test.js
@@ -37,7 +37,7 @@ describe('Acceptance: XRangeInput', function() {
     describe("changing the input value", function() {
       beforeEach(function() {
         Ember.$(".x-range-input").val("25");
-        Ember.$(".x-range-input").trigger('input');
+        Ember.$(".x-range-input").trigger('change');
       });
 
       it("changes the number", function() {


### PR DESCRIPTION
IE11 apparently does not fire input events on range inputs. We're going
to use the change event instead to be cross browser.

Related:  #9, #8 

CC: @optikalefx
