### PR TITLE
Remove two way data binding

### DIFF
--- a/addon/components/x-range-input.js
+++ b/addon/components/x-range-input.js
@@ -99,10 +99,6 @@ export default Ember.Component.extend({
   input() {
     let newValue = Number(this.get('element.value')).valueOf();
 
-    // Allow old school 2 way binding with the `mut` helper
-    this.set('value', newValue);
-
-    // But preferably, use the default action to work with the emitted value
     this.sendAction('action', newValue, this);
   },
 

--- a/tests/integration/components/x-range-input-test.js
+++ b/tests/integration/components/x-range-input-test.js
@@ -66,4 +66,21 @@ describeComponent('x-range-input', 'Integration: XRangeInputComponent', { integr
     });
 
   });
+
+  describe("moving the slider without an action", function() {
+    beforeEach(function() {
+      this.set('value', 50);
+      this.render(hbs`{{x-range-input value=value}}`);
+    });
+
+    beforeEach(function() {
+      // Change the value of the component like we've dragged it.
+      this.$('input').val(60).trigger('input');
+    });
+
+    it("shouldn't update the value", function() {
+      expect(this.get('value')).to.equal(50);
+    });
+  });
+
 });


### PR DESCRIPTION
For 2.0.0 we want to remove two way data binding. Should close #14 
