### PR TITLE
fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # emberx-range-input
 
-[![Build Status](https://travis-ci.org/thefrontside/emberx-slider.svg)](https://travis-ci.org/thefrontside/emberx-range-input)
+[![Build Status](https://travis-ci.org/thefrontside/emberx-range-input.svg?branch=master)](https://travis-ci.org/thefrontside/emberx-range-input)
 [![Ember Observer Score](http://emberobserver.com/badges/emberx-range-input.svg)](http://emberobserver.com/addons/emberx-range-input)
 [![npm version](https://badge.fury.io/js/emberx-range-input.svg)](https://badge.fury.io/js/emberx-range-input)
 [![Ember Badge](https://embadge.io/b/2.svg)](https://embadge.io/badges/2)


### PR DESCRIPTION
The build badge was pointing not at master, but at the generic travis build 
which falsely indicated that it was failing. If you don't specify a branch in the 
badge, then it will point at the latest build which could be some rando branch.