### PR TITLE
Fix tagName for Ember FastBoot

### DIFF
--- a/addon/components/x-range-input.js
+++ b/addon/components/x-range-input.js
@@ -14,7 +14,7 @@ import Ember from 'ember';
  */
 export default Ember.Component.extend({
   type: 'range',
-  tagName: ['input'],
+  tagName: 'input',
   classNames: ['x-range-input'],
   attributeBindings: ['min', 'max', 'step', 'type', 'name', 'list', 'disabled'],
 


### PR DESCRIPTION
While a `tagName` of `['input']` works it throws an error in Ember FastBoot. Instead it should be a string.

See https://github.com/ember-fastboot/ember-cli-fastboot/issues/365